### PR TITLE
Decouple svn add status code from svn commit

### DIFF
--- a/tasks/ivantage_svn_changelog.js
+++ b/tasks/ivantage_svn_changelog.js
@@ -145,8 +145,8 @@ module.exports = function(grunt) {
 
         grunt.log.ok('CHANGELOG written to: ' + opts.outFile);
 
+        run('svn add "' + opts.outFile +'"');
         var checkinStatusCode =
-          run('svn add "' + opts.outFile +'"').code +
           run('svn ci "' + opts.outFile + '" -m "chore: Add changelog (' + revFrom + ' - ' + revTo + ')"').code;
 
         if(checkinStatusCode === 0) {


### PR DESCRIPTION
Fixes #5 in the simplest way possible. If `svn add` fails because CHANGELOG is already under version control, the task will continue without worrying about it, and will only fail if the commit fails.
